### PR TITLE
[refactor] remove test and dev config files in published version

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -67,3 +67,12 @@ yarn.lock
 
 # Github actions
 .github/workflows
+
+# Project Tests
+test
+
+# Project Dev Configs
+.eslintignore
+.eslintrc
+.editorconfig
+.nycrc


### PR DESCRIPTION
I've notice those files in the npm published version. 

There is a reason why it was published this way?

Sorry if I did not follow a template I did not find a contributing guide. 

If this PR will be accepted I can do the same work at `array.prototype.flat` and `array.prototype.flatMap` projects. 